### PR TITLE
Fix ffigen generation

### DIFF
--- a/ffigen.yaml
+++ b/ffigen.yaml
@@ -1,7 +1,7 @@
 output: "lib/src/bindings.dart"
 headers:
   entry-points:
-    - "headers/git2/**.h"
+    - "headers/git2.h"
 compiler-opts:
   - '-I./headers'
   - '-DGIT_EXPERIMENTAL_SHA256=ON'


### PR DESCRIPTION
## Summary
- update ffigen config to reference `git2.h`
- run binding generation during dev workflow (removed after commit)

## Testing
- `dart format --set-exit-if-changed .`
- `dart run ffigen --config ffigen.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68443afacf34832db850ac460773663c