### PR TITLE
Fix ffigen generation

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - "main"
       # - "**"
+  pull_request:
+    branches:
+      - "**"
 env:
   PUB_ENVIRONMENT: bot.github
   LIBGIT2_VERSION: "1.9.1"
@@ -257,6 +260,7 @@ jobs:
 
   publish_package:
     needs: [run_tests]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/ffigen.yaml
+++ b/ffigen.yaml
@@ -1,7 +1,7 @@
 output: "lib/src/bindings.dart"
 headers:
   entry-points:
-    - "headers/git2/**.h"
+    - "headers/git2.h"
 compiler-opts:
   - '-I./headers'
   - '-DGIT_EXPERIMENTAL_SHA256=ON'


### PR DESCRIPTION
## Summary
- update ffigen config to reference `git2.h`
- run binding generation during dev workflow (removed after commit)
- update GitHub Actions to run on PRs and publish only from `main`

## Testing
- `dart format --set-exit-if-changed .` *(fails: formatted file not part of commit)*
- `dart run ffigen --config ffigen.yaml` *(failed: missing headers)*

------
https://chatgpt.com/codex/tasks/task_e_68443afacf34832db850ac460773663c