### PR TITLE
fix(macos): vendor libgit2 dylib under its install_name + add libssh2

### DIFF
--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -65,7 +65,12 @@ runs:
       shell: bash
       run: |
         mkdir -p export
-        cp /tmp/libgit2/install/lib/libgit2-experimental.dylib export/libgit2.dylib
+        # Export under the file name that matches the dylib's own
+        # install_name (@rpath/libgit2-experimental.1.9.dylib). The
+        # podspec vendors that exact name and util.dart opens it, so the
+        # built artifact MUST carry it too — otherwise dyld can't resolve
+        # the library at runtime (and `flutter test` fails to dlopen it).
+        cp /tmp/libgit2/install/lib/libgit2-experimental.dylib export/libgit2-experimental.1.9.dylib
         cp /tmp/libssh2/install/lib/libssh2.dylib export/libssh2.1.dylib
 
     - name: Cache git2 library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [Unreleased]
+### Fixed
+- macOS: vendored `libgit2.dylib` filename didn't match its
+  `install_name` (`@rpath/libgit2-experimental.1.9.dylib`), causing
+  Flutter macOS apps to SIGABRT at launch with
+  `Library not loaded: @rpath/libgit2-experimental.1.9.dylib`.
+- macOS: `libssh2.1.dylib` (a transitive dependency of libgit2) ships
+  with the package but was not declared in `vendored_libraries`, so it
+  was never embedded into consumer `.app` bundles. Apps that didn't
+  crash on the first defect failed on the second.
+- macOS: `lib/src/util.dart` requested `libgit2.dylib` from the
+  bundle's Frameworks directory, which doesn't match the renamed file
+  or its install_name. The package-config fallback path doesn't work
+  inside compiled Flutter apps (no `package_config.json` at runtime),
+  so the lookup failed with `Unable to resolve git2dart_binaries
+  package location`.
+
+Fixes [#14](https://github.com/DartGit-dev/git2dart_binaries/issues/14).
+
 ## [1.10.3] - 2025-11-20
 ### Fixed
 - Bug with .gitignore

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -16,7 +16,12 @@ String? _cachedPackageRoot;
   if (Platform.isWindows) {
     return (name: 'libgit2.dll', subDir: 'windows');
   } else if (Platform.isMacOS) {
-    return (name: 'libgit2.dylib', subDir: 'macos');
+    // Must match the filename the podspec vendors AND the dylib's own
+    // install_name (`@rpath/libgit2-experimental.1.9.dylib`). The
+    // package_config fallback in _loadLibrary doesn't work inside
+    // compiled Flutter apps (no package_config.json at runtime), so the
+    // first DynamicLibrary.open MUST succeed with this exact name.
+    return (name: 'libgit2-experimental.1.9.dylib', subDir: 'macos');
   } else if (Platform.isLinux) {
     return (name: 'libgit2.so', subDir: 'linux');
   } else if (Platform.isAndroid) {

--- a/macos/git2dart_binaries.podspec
+++ b/macos/git2dart_binaries.podspec
@@ -15,7 +15,12 @@ Dart bindings to libgit2.
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
-  s.vendored_libraries = 'libgit2.dylib'
+  # The libgit2 dylib's install_name is @rpath/libgit2-experimental.1.9.dylib,
+  # so the file must be vendored under that exact name or dyld can't find
+  # it inside the .app bundle at runtime. libssh2.1.dylib is a transitive
+  # dependency of libgit2 and must also be declared here so CocoaPods
+  # embeds it into the bundle's Frameworks directory.
+  s.vendored_libraries = ['libgit2-experimental.1.9.dylib', 'libssh2.1.dylib']
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }


### PR DESCRIPTION
Fixes #14.

Hi @vik-borisov — as requested. Three defects on macOS, each of which hid the next, all of which together prevent Flutter apps from loading libgit2 at runtime.

## The three defects

**1. Vendored dylib filename doesn't match its install_name.**
`libgit2.dylib` in the package has install_name `@rpath/libgit2-experimental.1.9.dylib`, but the podspec vendors the file under `libgit2.dylib`. CocoaPods embeds it into `MyApp.app/Contents/Frameworks/` under whatever name `vendored_libraries` declares — so dyld looks for `libgit2-experimental.1.9.dylib`, finds nothing, and the app SIGABRTs at launch with:

```
dyld: Library not loaded: @rpath/libgit2-experimental.1.9.dylib
  Referenced from: /Applications/MyApp.app/Contents/Frameworks/git2dart_binaries.framework/git2dart_binaries
  Reason: image not found
```

**Fix:** rename the vendored file to match its install_name (`libgit2-experimental.1.9.dylib`).

**2. `libssh2.1.dylib` is shipped but not declared.**
The `macos/` directory contains `libssh2.1.dylib` (a transitive dependency of libgit2 used for SSH transport), but the podspec only listed `libgit2.dylib`, so CocoaPods never embedded libssh2 into the consumer `.app` bundle. Apps that didn't crash on defect #1 then crashed here when libgit2 tried to dlopen libssh2.

**Fix:** declare both dylibs in `vendored_libraries`:
```ruby
s.vendored_libraries = ['libgit2-experimental.1.9.dylib', 'libssh2.1.dylib']
```

**3. `lib/src/util.dart` requests the wrong filename.**
The macOS branch of `_platformTarget()` returned `'libgit2.dylib'`, which doesn't match either the renamed file or the install_name. The fallback path in `_loadLibrary()` uses `Isolate.resolvePackageUriSync` — but that doesn't work inside compiled Flutter apps (there is no `package_config.json` at runtime), so the first `DynamicLibrary.open` MUST succeed by basename. The error surfaced as:

```
Bad state: Unable to resolve git2dart_binaries package location.
```

**Fix:** open `'libgit2-experimental.1.9.dylib'` on macOS so dyld resolves it through the bundle's `Frameworks/` rpath.

## Why all three are needed

Each defect masked the next. Fixing only #1 swaps the crash for #2's libssh2 miss. Fixing #1+#2 swaps that for #3's Dart-side lookup failure. The Flutter app I maintain (CCRLog) has been running with these three patches applied to the local pub-cache for several weeks across multiple machines without regression.

## What's NOT in this PR

- No version bump or CHANGELOG date — I left the `[Unreleased]` section open so you can pick the version.
- No Linux/Windows changes — those were already correct.
- No new tests — the failure modes are all runtime/packaging issues that aren't reachable from `flutter test` (they need a built `.app` bundle and a live runtime). I verified manually against a real macOS Flutter app build.

Happy to iterate on whatever you'd like adjusted.