### PR TITLE
fix(macos): vendor libgit2 dylib under its install_name + add libssh2…

### DIFF
--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -65,7 +65,12 @@ runs:
       shell: bash
       run: |
         mkdir -p export
-        cp /tmp/libgit2/install/lib/libgit2-experimental.dylib export/libgit2.dylib
+        # Export under the file name that matches the dylib's own
+        # install_name (@rpath/libgit2-experimental.1.9.dylib). The
+        # podspec vendors that exact name and util.dart opens it, so the
+        # built artifact MUST carry it too — otherwise dyld can't resolve
+        # the library at runtime (and `flutter test` fails to dlopen it).
+        cp /tmp/libgit2/install/lib/libgit2-experimental.dylib export/libgit2-experimental.1.9.dylib
         cp /tmp/libssh2/install/lib/libssh2.dylib export/libssh2.1.dylib
 
     - name: Cache git2 library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+##  [1.10.4] - 2026-05-29
 ### Fixed
 - macOS: vendored `libgit2.dylib` filename didn't match its
   `install_name` (`@rpath/libgit2-experimental.1.9.dylib`), causing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [Unreleased]
+### Fixed
+- macOS: vendored `libgit2.dylib` filename didn't match its
+  `install_name` (`@rpath/libgit2-experimental.1.9.dylib`), causing
+  Flutter macOS apps to SIGABRT at launch with
+  `Library not loaded: @rpath/libgit2-experimental.1.9.dylib`.
+- macOS: `libssh2.1.dylib` (a transitive dependency of libgit2) ships
+  with the package but was not declared in `vendored_libraries`, so it
+  was never embedded into consumer `.app` bundles. Apps that didn't
+  crash on the first defect failed on the second.
+- macOS: `lib/src/util.dart` requested `libgit2.dylib` from the
+  bundle's Frameworks directory, which doesn't match the renamed file
+  or its install_name. The package-config fallback path doesn't work
+  inside compiled Flutter apps (no `package_config.json` at runtime),
+  so the lookup failed with `Unable to resolve git2dart_binaries
+  package location`.
+
+Fixes [#14](https://github.com/DartGit-dev/git2dart_binaries/issues/14).
+
 ## [1.10.3] - 2025-11-20
 ### Fixed
 - Bug with .gitignore

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -16,7 +16,12 @@ String? _cachedPackageRoot;
   if (Platform.isWindows) {
     return (name: 'libgit2.dll', subDir: 'windows');
   } else if (Platform.isMacOS) {
-    return (name: 'libgit2.dylib', subDir: 'macos');
+    // Must match the filename the podspec vendors AND the dylib's own
+    // install_name (`@rpath/libgit2-experimental.1.9.dylib`). The
+    // package_config fallback in _loadLibrary doesn't work inside
+    // compiled Flutter apps (no package_config.json at runtime), so the
+    // first DynamicLibrary.open MUST succeed with this exact name.
+    return (name: 'libgit2-experimental.1.9.dylib', subDir: 'macos');
   } else if (Platform.isLinux) {
     return (name: 'libgit2.so', subDir: 'linux');
   } else if (Platform.isAndroid) {

--- a/macos/git2dart_binaries.podspec
+++ b/macos/git2dart_binaries.podspec
@@ -15,7 +15,12 @@ Dart bindings to libgit2.
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
-  s.vendored_libraries = 'libgit2.dylib'
+  # The libgit2 dylib's install_name is @rpath/libgit2-experimental.1.9.dylib,
+  # so the file must be vendored under that exact name or dyld can't find
+  # it inside the .app bundle at runtime. libssh2.1.dylib is a transitive
+  # dependency of libgit2 and must also be declared here so CocoaPods
+  # embeds it into the bundle's Frameworks directory.
+  s.vendored_libraries = ['libgit2-experimental.1.9.dylib', 'libssh2.1.dylib']
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: git2dart_binaries
 description: Dart bindings to libgit2, provides ability to use libgit2 library in Dart and Flutter.
-version: 1.10.3
+version: 1.10.4
 repository: https://github.com/DartGit-dev/git2dart_binaries
 
 environment:


### PR DESCRIPTION
… (#15)

* Fix macOS dylib packaging so Flutter apps can load libgit2 at runtime

Three defects on macOS caused Flutter apps to crash at launch or first sync attempt. Each layer hid the next: when one was fixed, the next surfaced. Issue #14.

1. The bundled libgit2.dylib had install_name `@rpath/libgit2-experimental.1.9.dylib`, but the podspec vendored the file under `libgit2.dylib`. dyld looks for the install_name inside the .app's Frameworks directory, finds nothing, and the app SIGABRTs with "Library not loaded: @rpath/libgit2-experimental.1.9.dylib". Fix: rename the vendored file to match its install_name.

2. libssh2.1.dylib (a transitive dependency of libgit2) shipped with the package but was not declared in `vendored_libraries`, so it was never embedded into the consumer .app bundle. Apps that didn't crash on defect #1 then crashed here. Fix: add libssh2.1.dylib to vendored_libraries.

3. `lib/src/util.dart` opened `libgit2.dylib`, which doesn't match either the renamed vendored file or the install_name. The fallback path uses `Isolate.resolvePackageUriSync`, which doesn't work inside compiled Flutter apps (no `package_config.json` at runtime), so the first DynamicLibrary.open MUST succeed. The error surfaced as "Bad state: Unable to resolve git2dart_binaries package location." Fix: open `libgit2-experimental.1.9.dylib` on macOS.

Verified against a real Flutter macOS app that was hitting all three: with these three changes applied, the app launches, libgit2 loads, and clone/fetch/push work end-to-end.

* fix(ci): export macOS dylib under its install_name

The macOS build copied the built dylib to `export/libgit2.dylib`, but the dylib's install_name is `@rpath/libgit2-experimental.1.9.dylib` — which is also the name the podspec vendors and `util.dart` passes to DynamicLibrary.open. The artifact name was the odd one out, so the `run_tests (macos)` job downloaded `libgit2.dylib` into `macos/` and then failed to dlopen `libgit2-experimental.1.9.dylib` ("no such file").

Export under the matching name so the artifact, the install_name, the podspec, and util.dart all agree. No code change needed elsewhere.